### PR TITLE
feat: Require explicit "star add" to bookmark directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,19 +26,23 @@ Also source the file in your `.bashrc` or `.zshrc`:
 ## Usage
 
 ```
-star [NAME|OPTION]
+star [OPTION [ARGUMENTS...]]
 ```
-Without `OPTION`:
-- Add the current directory to the list of starred directories.
-- The new star will be named after `NAME` if provided.
-- `NAME` must be unique (among all stars).
-- `NAME` can be anything that is not a reserved `OPTION` keywords (see below).
-- `NAME` can also contain slashes `/`.
+Without arguments:
+- Show this help message.
 
 With `OPTION`:
 - Will execute the feature associated with this option.
-- `OPTION` can be one of `list`, `load`, `remove`, `reset`, `help`, or one of there shortnames (such as `-h` for `help`). Use `star help` for more information on short parameters and aliases.
+- `OPTION` can be one of `add`, `list`, `load`, `rename`, `remove`, `reset`, `help`, or one of their shortnames (such as `-h` for `help`). Use `star help` for more information on short parameters and aliases.
 
+---
+```
+star add [NAME]
+```
+Add the current directory to the list of starred directories.
+The new star will be named after `NAME` if provided, otherwise it will use the basename of the current directory.
+`NAME` must be unique (among all stars).
+`NAME` can contain slashes `/`.
 
 ---
 ```
@@ -88,6 +92,7 @@ Get more information.
 > Use `star help` for all options and aliases.
 
 The following aliases are provided to make your life easier:
+- `sah` = star add
 - `sL` = star list
 - `sl` = star load (which is the same as "star list" when no argument is provided)
 - `unstar` = star remove
@@ -99,7 +104,7 @@ The following aliases are provided to make your life easier:
 fruchix@debian:~/Documents/star$ star list
 No ".star" directory (will be created when adding new starred directories).
 
-fruchix@debian:~/Documents/star$ star
+fruchix@debian:~/Documents/star$ star add
 Added new starred directory: star -> /home/fruchix/Documents/star
 
 fruchix@debian:~/Documents/star$ star list
@@ -107,7 +112,7 @@ star  ->  /home/fruchix/Documents/star
 
 fruchix@debian:~/Documents/star$ cd ..
 
-fruchix@debian:~/Documents$ star my/docs
+fruchix@debian:~/Documents$ star add my/docs
 Added new starred directory: my/docs -> /home/fruchix/Documents
 
 fruchix@debian:~/Documents$ sl

--- a/star.sh
+++ b/star.sh
@@ -37,16 +37,19 @@ star()
     local star stars_list stars_path src_dir opt current_pwd user_input force_reset
     star_help="Usage: star [NAME|OPTION]
 
-Without OPTION:
+Without arguments:
+- Show this help message.
+
+With NAME:
 - Add the current directory to the list of starred directories.
-- The new star will be named after NAME if provided.
+- The new star will be named after NAME.
 - NAME must be unique (among all stars).
-- NAME can be anything that is not a reserved OPTION keywords (see below).
+- NAME can be anything that is not a reserved OPTION keyword (see below).
 - NAME can also contain slashes /.
 
 With OPTION:
 - Will execute the feature associated with this option.
-- OPTION can be one of list, load, remove, reset, help, or one of there shortnames (such as -h for help).
+- OPTION can be one of list, load, remove, reset, help, or one of their shortnames (such as -h for help).
 
 OPTION
     L|list

--- a/star.sh
+++ b/star.sh
@@ -40,18 +40,18 @@ star()
 Without arguments:
 - Show this help message.
 
-With NAME:
-- Add the current directory to the list of starred directories.
-- The new star will be named after NAME.
-- NAME must be unique (among all stars).
-- NAME can be anything that is not a reserved OPTION keyword (see below).
-- NAME can also contain slashes /.
-
 With OPTION:
 - Will execute the feature associated with this option.
-- OPTION can be one of list, load, remove, reset, help, or one of their shortnames (such as -h for help).
+- OPTION can be one of add, list, load, remove, reset, help, or one of their shortnames (such as -h for help).
 
 OPTION
+    add [NAME]
+        Add the current directory to the list of starred directories.
+        The new star will be named after NAME if provided, otherwise it will
+        use the basename of the current directory.
+        NAME must be unique (among all stars).
+        NAME can contain slashes /.
+
     L|list
         List all starred directories, sorted according to last load (top ones are the last loaded stars).
 
@@ -92,10 +92,10 @@ The following aliases are provided:
     # Parse the arguments
 
     positional_args=()
-    star_to_store="${1-}"   # default value is an empty string if $1 is unset
+    star_to_store=""  # No longer setting $1 as the default star name
     stars_to_remove=()
     force_reset=0
-    mode=STORE
+    mode=HELP  # Default mode changed to HELP instead of STORE
 
     # If no arguments are provided, show help
     if [[ $# -eq 0 ]]; then
@@ -115,6 +115,15 @@ The following aliases are provided:
         case "$opt" in
             "--" ) break 2;;
             "-" ) break 2;;
+            "add" )
+                mode=STORE
+                # If there's an argument after "add", use it as star name
+                if [[ $# -gt 0 && ! "$1" =~ ^- ]]; then
+                    star_to_store="$1"
+                    shift
+                fi
+                break
+                ;;
             "reset" )
                 mode=RESET
                 if [[ "$1" == "-f" || "$1" == "--force" ]]; then
@@ -363,7 +372,7 @@ _star_completion()
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="load rename remove list reset help"
+    opts="add load rename remove list reset help"
 
     # first and second comp words
     first_cw="${COMP_WORDS[COMP_CWORD-COMP_CWORD]}"

--- a/star.sh
+++ b/star.sh
@@ -92,10 +92,10 @@ The following aliases are provided:
     # Parse the arguments
 
     positional_args=()
-    star_to_store=""  # No longer setting $1 as the default star name
+    star_to_store=""
     stars_to_remove=()
     force_reset=0
-    mode=HELP  # Default mode changed to HELP instead of STORE
+    mode=HELP
 
     # If no arguments are provided, show help
     if [[ $# -eq 0 ]]; then
@@ -418,12 +418,14 @@ alias sl="star l"       # star load
 alias sL="star L"       # star list
 alias srm="star rm"     # star remove
 alias unstar="star rm"  # star remove
+alias sah="star add"    # star add
 
 # activate completion for this program and the aliases
 complete -F _star_completion star
 complete -F _star_completion sl
 complete -F _star_completion srm
 complete -F _star_completion unstar
+complete -F _star_completion sah
 
 # remove broken symlinks directly when sourcing this file
 _star_prune

--- a/star.sh
+++ b/star.sh
@@ -94,6 +94,12 @@ The following aliases are provided:
     force_reset=0
     mode=STORE
 
+    # If no arguments are provided, show help
+    if [[ $# -eq 0 ]]; then
+        echo "${star_help}"
+        return
+    fi
+
     while [[ $# -gt 0 ]]; do
         opt="$1"
         shift


### PR DESCRIPTION
This commit changes the behavior of the star utility to require explicit
intention when bookmarking directories:

1. Added a new "add" command that must be used to bookmark directories
2. Changed default mode from STORE to HELP when no arguments are provided
3. Updated help text to document the new command and removed outdated instructions
4. Added "add" to command completion options

**BREAKING CHANGE: Users must now type "star add [NAME]" to bookmark a directory**, rather than just "star [NAME]". 

**Running "star" without arguments now displays help instead of bookmarking the current directory.**

This change follows the principle of least surprise by making powerful actions require explicit commands. This prevents accidental bookmarking of directories when a user is just exploring the tool's functionality.
