### PR TITLE
Feature: set environment variables according to starred directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ or `.zshrc`:
 echo "source $(pwd)/star.sh" >> ~/.zshrc
 ```
 
+### Customization
+
+You can customize star by editing the following variables at the top of the `star.sh` file:
+
+| Variable | Value | Description |
+| - | - | - |
+| `_STAR_EXPORT_ENV_VARIABLES` | `yes\|no` | Enable or disable [environment variables](#environment-variables). |
+| `_STAR_ENV_PREFIX` | String composed of upper case letters and underscores | The common prefix of the environment variables created according to the star names |
+| `_STAR_DIR` | Path | Directory in which to store the symbolink links (stars). Will be created if it does not exist. Will be removed when resetting star. |
+
+I strongly advise against modifying the value of `_STAR_DIR_SEPARATOR`.
 
 ## Usage
 
@@ -141,6 +152,31 @@ fruchix@debian:~/Documents/star$ sl my/docs
 fruchix@debian:~/Documents$ unstar my/docs
 Removed starred directory: my/docs
 ```
+
+## Environment variables
+
+To allow users to list, copy or even archive their files located in a starred directory, `star` exports environment variables that leads to them.
+
+For each starred directory, an environment variable is exported with the format: `STAR_NAME=/path/to/starred/directory`. 
+
+For example, with the following stars:
+- work
+- one-drive
+- projects/star
+
+The following environment variables will be exported:
+- STAR_WORK
+- STAR_ONE_DRIVE
+- STAR_PROJECTS_STAR
+
+By default, the prefix of the environment variable is "STAR_", but it can be edited by changing the value of `_STAR_ENV_PREFIX` (see [Customization](#customization)).
+
+This default prefix allows users to type `$STAR` then use tab and autocompletion to select a starred directory.
+
+Example usages:
+- List files in starred directory: `ls $STAR_WORK`
+- Copy a file: `cp $STAR_ONE_DRIVE/myfile .`
+
 
 ## License
 

--- a/star.sh
+++ b/star.sh
@@ -1,11 +1,18 @@
 #!/usr/bin/env bash
 
+# Directory in which to store the symlinks (stars)
+# Will be created if it does not exist, and will be removed when resetting star
+export _STAR_DIR="$HOME/.star"
+
 # Enable (yes) or disable (no) environment variables
 export _STAR_EXPORT_ENV_VARIABLES="yes"
 
-export _STAR_DIR="$HOME/.star"
-export _STAR_DIR_SEPARATOR="»"
+# The common prefix of the environment variables created according to the star names
 export _STAR_ENV_PREFIX="STAR_"
+
+# A character used to replace slashes in the star names
+# This should not be changed
+export _STAR_DIR_SEPARATOR="»"
 
 if [ -t 1 ]; then
     # Check for truecolor support

--- a/star.sh
+++ b/star.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Enable (yes) or disable (no) environment variables
+export _STAR_EXPORT_ENV_VARIABLES="yes"
+
 export _STAR_DIR="$HOME/.star"
 export _STAR_DIR_SEPARATOR="»"
 export _STAR_ENV_PREFIX="STAR_"
@@ -24,6 +27,10 @@ export _STAR_COLOR_PATH
 
 _star_set_variables()
 {
+    if [[ $_STAR_EXPORT_ENV_VARIABLES != "yes" ]]; then
+        return
+    fi
+
     local stars_list star star_name star_path line env_var_name shell
 
     stars_list=()


### PR DESCRIPTION
Allow users to open, list, copy, (and more) files by exporting environment variables with the format: `STAR_NAME=/path/to/star/directory`.

For example, with the following stars:
- work
- one-drive
- projects/star

The following environment variables will be exported:
- STAR_WORK
- STAR_ONE_DRIVE
- STAR_PROJECTS_STAR

By default, the prefix of the environment variable is "STAR_", but it can be edited by changing the value of `_STAR_ENV_PREFIX` (see [Customization](#customization)).

Example usages:
- List files in starred directory: `ls $STAR_WORK`
- Copy a file: `cp $STAR_ONE_DRIVE/myfile .`
