### PR TITLE
feat: add flake support

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-use flake

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/result
+/.direnv/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /result
 /.direnv/
+.envrc

--- a/README.md
+++ b/README.md
@@ -386,6 +386,27 @@ echo '[[ ":${PATH}:" =~ ":/usr/local/bin:" ]] || export PATH="/usr/local/bin:$PA
 echo 'eval "$(command star init zsh)"' >> ~/.zshrc
 ```
 
+<details>
+  <summary>Installation on Nix</summary>
+
+If you're using Nix or NixOS, you can install star using the provided flake:
+
+```sh
+# Run directly without installing
+nix run github:Fruchix/star
+
+# Install to your user profile
+nix profile install github:Fruchix/star
+
+# Or add to your flake inputs and use in your configuration
+```
+
+After installation, initialize star in your shell configuration:
+```sh
+eval "$(command star init "$([[ -n $BASH_VERSION ]] && echo bash || echo zsh)")"
+```
+
+</details>
 
 ### Uninstalling
 

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1763966396,
-        "narHash": "sha256-6eeL1YPcY1MV3DDStIDIdy/zZCDKgHdkCmsrLJFiZf0=",
+        "lastModified": 1764020296,
+        "narHash": "sha256-6zddwDs2n+n01l+1TG6PlyokDdXzu/oBmEejcH5L5+A=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5ae3b07d8d6527c42f17c876e404993199144b6a",
+        "rev": "a320ce8e6e2cc6b4397eef214d202a50a4583829",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flakeutils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1763966396,
+        "narHash": "sha256-6eeL1YPcY1MV3DDStIDIdy/zZCDKgHdkCmsrLJFiZf0=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5ae3b07d8d6527c42f17c876e404993199144b6a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flakeutils": "flakeutils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+{
+  description = "A Unix command line bookmark manager.";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    flakeutils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flakeutils }:
+    flakeutils.lib.eachDefaultSystem (system:
+      let pkgs = nixpkgs.legacyPackages.${system}; in
+      {
+        packages = rec {
+          default = pkgs.stdenv.mkDerivation {
+            name = "star";
+            src = ./.;
+            buildInputs = with pkgs; [
+              coreutils
+              findutils
+              unixtools.column
+              bash
+            ];
+            installPhase = ''
+            ./configure --prefix="$out"
+            bash ./install.sh
+            '';
+          };
+        };
+      }
+    );
+}
+
+
+

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "A Unix command line bookmark manager.";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-25.11";
     flakeutils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
This PR adds flake support to star which allows users of the Nix package manager or NixOS to run `nix build` to build the package, and `nix develop` to drop into a shell with all the dependencies installed.